### PR TITLE
Tabular-related tags

### DIFF
--- a/packages/docs/pages/reference/elements/cell.mdx
+++ b/packages/docs/pages/reference/elements/cell.mdx
@@ -11,14 +11,16 @@ import {
 The `<cell>` tag is used to define entries in a [`<row>`](row) which itself is
 contained in a [`<tabular>`](tabular) environment. Each `<cell>` has options to
 modify its bottom and right borders, horizontal alignment of the contents of
-that cell, or indicate via the `colspan` option how many columns in the given row that cell should occupy.
+that cell, or indicate via the `colspan` option how many columns in the given
+ row that cell should occupy.
 
 Horizontal alignment can be adjusted on a per-cell basis, but usually one
-defines alignment for [`<col>`](col) tags, instead.  Vertical alignment can only be adjusted at the level of a [`<row>`](row) or the entire
+defines alignment for [`<col>`](col) tags, instead.  Vertical alignment can
+ only be adjusted at the level of a [`<row>`](row) or the entire
 [`<tabular>`](tabular) level.
 
-Examples from the [`<tabular>`](tabular) or [`<table>`](table) tags demonstrate
-most of the variations which are available.
+Additional examples from the [`<tabular>`](tabular) or [`<table>`](table) tags
+demonstrate many other variations which are possible.
 
 ## Syntax
 

--- a/packages/docs/pages/reference/elements/cell.mdx
+++ b/packages/docs/pages/reference/elements/cell.mdx
@@ -1,9 +1,9 @@
 import {
-    AttrDisplay,
-    ChildrenDisplay,
-    ParentsDisplay,
-    PtxExample,
-    SyntaxDisplay,
+  AttrDisplay,
+  ChildrenDisplay,
+  ParentsDisplay,
+  PtxExample,
+  SyntaxDisplay,
 } from "../../../components";
 
 # `<cell>`
@@ -12,11 +12,11 @@ The `<cell>` tag is used to define entries in a [`<row>`](row) which itself is
 contained in a [`<tabular>`](tabular) environment. Each `<cell>` has options to
 modify its bottom and right borders, horizontal alignment of the contents of
 that cell, or indicate via the `colspan` option how many columns in the given
- row that cell should occupy.
+row that cell should occupy.
 
 Horizontal alignment can be adjusted on a per-cell basis, but usually one
-defines alignment for [`<col>`](col) tags, instead.  Vertical alignment can
- only be adjusted at the level of a [`<row>`](row) or the entire
+defines alignment for [`<col>`](col) tags, instead. Vertical alignment can
+only be adjusted at the level of a [`<row>`](row) or the entire
 [`<tabular>`](tabular) level.
 
 Additional examples from the [`<tabular>`](tabular) or [`<table>`](table) tags
@@ -30,42 +30,22 @@ demonstrate many other variations which are possible.
 
 ```ptx-example
 <FRAGMENT parents="section subsection">
- <sidebyside>
-        <table>
-          <title>Default options set bottom and right borders</title>
-          <tabular bottom="minor" right="minor">
-            <row>
-              <cell>A</cell>
-              <cell>B</cell>
-              <cell>C</cell>
-              <cell>D</cell>
-            </row>
-            <row>
-              <cell>E</cell>
-              <cell>F</cell>
-              <cell>G</cell>
-              <cell>H</cell>
-            </row>
-          </tabular>
-        </table>
-
-      <table>
-          <title>Cell options override defaults</title>
-          <tabular bottom="minor" right="minor">
-            <row>
-              <cell>A</cell>
-              <cell right="major">B</cell>
-              <cell>C</cell>
-              <cell>D</cell>
-            </row>
-            <row>
-              <cell>E</cell>
-              <cell>F</cell>
-              <cell bottom="none">G</cell>
-              <cell>H</cell>
-            </row>
-          </tabular>
-        </table>
-        </sidebyside>
-        </FRAGMENT>
+  <table>
+    <title>Cell border options override defaults</title>
+    <tabular bottom="minor" right="minor">
+      <row>
+        <cell>A</cell>
+        <cell right="major">B</cell>
+        <cell>C</cell>
+        <cell>D</cell>
+      </row>
+      <row>
+        <cell>E</cell>
+        <cell>F</cell>
+        <cell bottom="none">G</cell>
+        <cell>H</cell>
+       </row>
+    </tabular>
+  </table>
+</FRAGMENT>
 ```

--- a/packages/docs/pages/reference/elements/cell.mdx
+++ b/packages/docs/pages/reference/elements/cell.mdx
@@ -26,6 +26,44 @@ most of the variations which are available.
 
 ## Examples
 
- Refer to the examples for the [`<tabular>`](tabular) or [`<table>`](table) tags  which demonstrate most of the variations which are available.   [Table 4.18.3]
-(https://pretextbook.org/doc/guide/html/topic-tabular.html#topic-tabular-13-7)
-gives further detail.
+```ptx-example
+<FRAGMENT parents="section subsection">
+ <sidebyside>
+        <table>
+          <title>Default options set bottom and right borders</title>
+          <tabular bottom="minor" right="minor">
+            <row>
+              <cell>A</cell>
+              <cell>B</cell>
+              <cell>C</cell>
+              <cell>D</cell>
+            </row>
+            <row>
+              <cell>E</cell>
+              <cell>F</cell>
+              <cell>G</cell>
+              <cell>H</cell>
+            </row>
+          </tabular>
+        </table>
+
+      <table>
+          <title>Cell options override defaults</title>
+          <tabular bottom="minor" right="minor">
+            <row>
+              <cell>A</cell>
+              <cell right="major">B</cell>
+              <cell>C</cell>
+              <cell>D</cell>
+            </row>
+            <row>
+              <cell>E</cell>
+              <cell>F</cell>
+              <cell bottom="none">G</cell>
+              <cell>H</cell>
+            </row>
+          </tabular>
+        </table>
+        </sidebyside>
+        </FRAGMENT>
+```

--- a/packages/docs/pages/reference/elements/cell.mdx
+++ b/packages/docs/pages/reference/elements/cell.mdx
@@ -8,7 +8,17 @@ import {
 
 # `<cell>`
 
-Short description of what the `<cell>` tag does.
+The `<cell>` tag is used to define entries in a [`<row>`](row) which itself is
+contained in a [`<tabular>`](tabular) environment. Each `<cell>` has options to
+modify its bottom and right borders, horizontal alignment of the contents of
+that cell, or indicate via the `colspan` option how many columns in the given row that cell should occupy.
+
+Horizontal alignment can be adjusted on a per-cell basis, but usually one
+defines alignment for [`<col>`](col) tags, instead.  Vertical alignment can only be adjusted at the level of a [`<row>`](row) or the entire
+[`<tabular>`](tabular) level.
+
+Examples from the [`<tabular>`](tabular) or [`<table>`](table) tags demonstrate
+most of the variations which are available.
 
 ## Syntax
 
@@ -16,4 +26,6 @@ Short description of what the `<cell>` tag does.
 
 ## Examples
 
-    
+ Refer to the examples for the [`<tabular>`](tabular) or [`<table>`](table) tags  which demonstrate most of the variations which are available.   [Table 4.18.3]
+(https://pretextbook.org/doc/guide/html/topic-tabular.html#topic-tabular-13-7)
+gives further detail.

--- a/packages/docs/pages/reference/elements/col.mdx
+++ b/packages/docs/pages/reference/elements/col.mdx
@@ -8,7 +8,11 @@ import {
 
 # `<col>`
 
-Short description of what the `<col>` tag does.
+The `<col>` tag is optionally used in a [`<tabular>`](tabular) environment. Its primary use is to define horizontal alignment within a column or to specify by percentage how much of the tabular environment the column should occupy.
+
+If the `<col>` tag does appear, it must occur prior to any rows and must occur
+exactly as many times as there will be columns.
+
 
 ## Syntax
 
@@ -16,4 +20,4 @@ Short description of what the `<col>` tag does.
 
 ## Examples
 
-    
+Representative examples for the use of this tag are found in the examples for  the [`<tabular>`](tabular) and [`<table>`](table) tags.

--- a/packages/docs/pages/reference/elements/col.mdx
+++ b/packages/docs/pages/reference/elements/col.mdx
@@ -8,7 +8,10 @@ import {
 
 # `<col>`
 
-The `<col>` tag is optionally used in a [`<tabular>`](tabular) environment. Its primary use is to define horizontal alignment within a column or to specify by percentage how much of the tabular environment the column should occupy.
+The `<col>` tag is optionally used in a [`<tabular>`](tabular) environment.
+ Its primary use is to define horizontal alignment within a column or to 
+ specify by percentage how much of the tabular environment the column should
+  occupy.
 
 If the `<col>` tag does appear, it must occur prior to any rows and must occur
 exactly as many times as there will be columns.
@@ -20,7 +23,9 @@ exactly as many times as there will be columns.
 
 ## Notes
 
-The `width` option will only affect columns containing a cell with a `&lt;p&gt;&lt; /p&gt;`.  Conversely, the use of a `&lt;p&gt;&lt; /p&gt;` tag inside a cell necessitates the use of a `&lt;col /&gt;` preamble to the rows of a `&lt;tabular&gt;`.
+The `width` option will only be applied to columns containing a cell with 
+a `<p>`.  Conversely, the use of a `<p>` tag inside a cell necessitates the
+ use of a `<col>` preamble to the rows of a `<tabular>`.
 
 ## Examples
 

--- a/packages/docs/pages/reference/elements/col.mdx
+++ b/packages/docs/pages/reference/elements/col.mdx
@@ -18,6 +18,61 @@ exactly as many times as there will be columns.
 
 <SyntaxDisplay name="col" />
 
+## Notes
+
+The `width` option will only affect columns containing a cell with a `&lt;p&gt;&lt; /p&gt;`.  Conversely, the use of a `&lt;p&gt;&lt; /p&gt;` tag inside a cell necessitates the use of a `&lt;col /&gt;` preamble to the rows of a `&lt;tabular&gt;`.
+
 ## Examples
 
-Representative examples for the use of this tag are found in the examples for  the [`<tabular>`](tabular) and [`<table>`](table) tags.
+```ptx-example
+<FRAGMENT parents="section subsection">
+    <table>
+          <title>Column options (top="minor" right="medium")</title>
+          <tabular>
+          <col top="minor" right="medium"/>
+            <row>
+              <cell>A</cell>
+              </row>
+               <row>
+                <cell>C</cell>
+               </row>
+          </tabular>
+        </table>
+</FRAGMENT>
+```
+
+```ptx-example
+<FRAGMENT parents="section subsection">
+<table>
+          <title>Column options halign and width</title>
+          <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
+            <col halign="left" width="35%" />
+            <col halign="left" />
+            <col halign="center"/>
+            <col halign="right" width="25%"/>
+            <row>
+              <cell>Paragraphs</cell>
+              <cell>Column 2</cell>
+              <cell>Column 3</cell>
+              <cell>Column 4</cell>
+            </row>
+            <row>
+              <cell>
+                <p>The quick brown fox jumps over the lazy brown dog.</p>
+              </cell>
+              <cell>B</cell>
+              <cell>C</cell>
+              <cell> <p>D</p></cell>
+            </row>
+            <row>
+              <cell>
+                <p>A</p>
+              </cell>
+              <cell>B</cell>
+              <cell>C</cell>
+              <cell> <p>The quick brown fox jumps over the lazy brown dog</p></cell>
+            </row>
+          </tabular>
+        </table>
+</FRAGMENT>
+```

--- a/packages/docs/pages/reference/elements/col.mdx
+++ b/packages/docs/pages/reference/elements/col.mdx
@@ -31,53 +31,51 @@ a `<p>`.  Conversely, the use of a `<p>` tag inside a cell necessitates the
 
 ```ptx-example
 <FRAGMENT parents="section subsection">
-    <table>
-          <title>Column options (top="minor" right="medium")</title>
-          <tabular>
-          <col top="minor" right="medium"/>
-            <row>
-              <cell>A</cell>
-              </row>
-               <row>
-                <cell>C</cell>
-               </row>
-          </tabular>
-        </table>
+  <table>
+    <title>Column border options</title>
+    <tabular>
+      <col top="minor" right="medium"/>
+        <row>
+          <cell>A</cell>
+        </row>
+        <row>
+          <cell>C</cell>
+        </row>
+    </tabular>
+  </table>
 </FRAGMENT>
 ```
 
 ```ptx-example
 <FRAGMENT parents="section subsection">
 <table>
-          <title>Column options halign and width</title>
-          <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
-            <col halign="left" width="35%" />
-            <col halign="left" />
-            <col halign="center"/>
-            <col halign="right" width="25%"/>
-            <row>
-              <cell>Paragraphs</cell>
-              <cell>Column 2</cell>
-              <cell>Column 3</cell>
-              <cell>Column 4</cell>
-            </row>
-            <row>
-              <cell>
-                <p>The quick brown fox jumps over the lazy brown dog.</p>
-              </cell>
-              <cell>B</cell>
-              <cell>C</cell>
-              <cell> <p>D</p></cell>
-            </row>
-            <row>
-              <cell>
-                <p>A</p>
-              </cell>
-              <cell>B</cell>
-              <cell>C</cell>
-              <cell> <p>The quick brown fox jumps over the lazy brown dog</p></cell>
-            </row>
-          </tabular>
-        </table>
+  <title>Column options halign and width</title>
+  <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
+    <col halign="left" width="35%" />
+    <col halign="left" />
+    <col halign="center"/>
+    <col halign="right" width="25%"/>
+    <row>
+      <cell>Paragraphs</cell>
+      <cell>Column 2</cell>
+      <cell>Column 3</cell>
+      <cell>Column 4</cell>
+    </row>
+    <row>
+      <cell>
+        <p>The quick brown fox jumps over the lazy brown dog.</p>
+      </cell>
+      <cell>B</cell>
+      <cell>C</cell>
+      <cell><p>D</p></cell>
+    </row>
+    <row>
+      <cell><p>A</p></cell>
+      <cell>B</cell>
+      <cell>C</cell>
+      <cell><p>The quick brown fox jumps over the lazy brown dog</p></cell>
+    </row>
+  </tabular>
+</table>
 </FRAGMENT>
 ```

--- a/packages/docs/pages/reference/elements/row.mdx
+++ b/packages/docs/pages/reference/elements/row.mdx
@@ -1,9 +1,9 @@
 import {
-    AttrDisplay,
-    ChildrenDisplay,
-    ParentsDisplay,
-    PtxExample,
-    SyntaxDisplay,
+  AttrDisplay,
+  ChildrenDisplay,
+  ParentsDisplay,
+  PtxExample,
+  SyntaxDisplay,
 } from "../../../components";
 
 # `<row>`
@@ -20,4 +20,76 @@ adjust horizotal and vertical alignments of content within the row.
 
 ## Examples
 
-Representative examples for the use of this tag are found in the examples for the [`<tabular>`](tabular) and [`<table>`](table) tags.
+```ptx-example
+<FRAGMENT parents="section subsection">
+    <table>
+          <title>Row options (left="minor" bottom="medium")</title>
+          <tabular>
+            <row left="minor" bottom="medium">
+              <cell>A</cell>
+              <cell>B</cell>
+              <cell>C</cell>
+              <cell>D</cell>
+            </row>
+          </tabular>
+        </table>
+</FRAGMENT>
+```
+
+```ptx-example
+<FRAGMENT parents="section subsection">
+    <table>
+          <title>Row option halign (1-left; 2-right; 3-center)</title>
+          <tabular>
+            <row halign="left">
+              <cell>AAAAAAAAAA</cell>
+              <cell>BBBBBB</cell>
+            </row>
+              <row halign="right">
+              <cell>A</cell>
+              <cell>B</cell>
+            </row>
+            <row halign="center">
+              <cell>AA A AA</cell>
+              <cell>B BB B</cell>
+            </row>
+          </tabular>
+        </table>
+</FRAGMENT>
+```
+
+```ptx-example
+<FRAGMENT parents="section subsection">
+  <table>
+          <title>Row option valign (1-top; 2-bottom; 3-center)</title>
+          <tabular>
+          <col width="60%"/>
+          <col/>
+            <row valign="top" left="minor" bottom="minor">
+              <cell right="minor">
+                <p>
+                  We use a paragraph here to generate enough vertical space to demonstrate the vertical alignments.
+                </p>
+              </cell>
+              <cell>BBBBBB</cell>
+            </row>
+            <row valign="bottom" left="minor" bottom="minor">
+              <cell right="minor">
+                <p>
+                  We use a paragraph here to generate enough vertical space to demonstrate the vertical alignments.
+                </p>
+              </cell>
+              <cell>B</cell>
+            </row>
+            <row valign="middle" left="minor" bottom="minor">
+              <cell right="minor">
+                <p>
+                  We use a paragraph here to generate enough vertical space to demonstrate the vertical alignments.
+                </p>
+              </cell>
+              <cell>B BB B</cell>
+            </row>
+          </tabular>
+        </table>
+ </FRAGMENT>
+```

--- a/packages/docs/pages/reference/elements/row.mdx
+++ b/packages/docs/pages/reference/elements/row.mdx
@@ -8,7 +8,11 @@ import {
 
 # `<row>`
 
-Short description of what the `<row>` tag does.
+The `<row>` tag is used in a [`<tabular>`](tabular) environment to provide a
+wrapper for all the cells [`<cell>`](cell)  (column entires) that will occur in
+that row.  It has options to affect left and bottom borders of the row and can
+adjust horizotal and vertical alignments of content within the row.
+
 
 ## Syntax
 
@@ -16,4 +20,4 @@ Short description of what the `<row>` tag does.
 
 ## Examples
 
-    
+Representative examples for the use of this tag are found in the examples for the [`<tabular>`](tabular) and [`<table>`](table) tags.

--- a/packages/docs/pages/reference/elements/row.mdx
+++ b/packages/docs/pages/reference/elements/row.mdx
@@ -11,7 +11,7 @@ import {
 The `<row>` tag is used in a [`<tabular>`](tabular) environment to provide a
 wrapper for all the cells [`<cell>`](cell)  (column entires) that will occur in
 that row.  It has options to affect left and bottom borders of the row and can
-adjust horizotal and vertical alignments of content within the row.
+adjust horizontal and vertical alignments of content within the row.
 
 
 ## Syntax
@@ -23,7 +23,7 @@ adjust horizotal and vertical alignments of content within the row.
 ```ptx-example
 <FRAGMENT parents="section subsection">
     <table>
-          <title>Row options (left="minor" bottom="medium")</title>
+          <title>Row option (borders)</title>
           <tabular>
             <row left="minor" bottom="medium">
               <cell>A</cell>
@@ -39,7 +39,7 @@ adjust horizotal and vertical alignments of content within the row.
 ```ptx-example
 <FRAGMENT parents="section subsection">
     <table>
-          <title>Row option halign (1-left; 2-right; 3-center)</title>
+          <title>Row option (halign)</title>
           <tabular>
             <row halign="left">
               <cell>AAAAAAAAAA</cell>
@@ -61,14 +61,15 @@ adjust horizotal and vertical alignments of content within the row.
 ```ptx-example
 <FRAGMENT parents="section subsection">
   <table>
-          <title>Row option valign (1-top; 2-bottom; 3-center)</title>
+          <title>Row option (valign)</title>
           <tabular>
           <col width="60%"/>
           <col/>
             <row valign="top" left="minor" bottom="minor">
               <cell right="minor">
                 <p>
-                  We use a paragraph here to generate enough vertical space to demonstrate the vertical alignments.
+                  We use a paragraph here to generate enough vertical space
+                   to demonstrate the vertical alignments.
                 </p>
               </cell>
               <cell>BBBBBB</cell>
@@ -76,7 +77,8 @@ adjust horizotal and vertical alignments of content within the row.
             <row valign="bottom" left="minor" bottom="minor">
               <cell right="minor">
                 <p>
-                  We use a paragraph here to generate enough vertical space to demonstrate the vertical alignments.
+                  We use a paragraph here to generate enough vertical space
+                   to demonstrate the vertical alignments.
                 </p>
               </cell>
               <cell>B</cell>
@@ -84,7 +86,8 @@ adjust horizotal and vertical alignments of content within the row.
             <row valign="middle" left="minor" bottom="minor">
               <cell right="minor">
                 <p>
-                  We use a paragraph here to generate enough vertical space to demonstrate the vertical alignments.
+                  We use a paragraph here to generate enough vertical space
+                   to demonstrate the vertical alignments.
                 </p>
               </cell>
               <cell>B BB B</cell>

--- a/packages/docs/pages/reference/elements/row.mdx
+++ b/packages/docs/pages/reference/elements/row.mdx
@@ -22,77 +22,77 @@ adjust horizontal and vertical alignments of content within the row.
 
 ```ptx-example
 <FRAGMENT parents="section subsection">
-    <table>
-          <title>Row option (borders)</title>
-          <tabular>
-            <row left="minor" bottom="medium">
-              <cell>A</cell>
-              <cell>B</cell>
-              <cell>C</cell>
-              <cell>D</cell>
-            </row>
-          </tabular>
-        </table>
-</FRAGMENT>
-```
-
-```ptx-example
-<FRAGMENT parents="section subsection">
-    <table>
-          <title>Row option (halign)</title>
-          <tabular>
-            <row halign="left">
-              <cell>AAAAAAAAAA</cell>
-              <cell>BBBBBB</cell>
-            </row>
-              <row halign="right">
-              <cell>A</cell>
-              <cell>B</cell>
-            </row>
-            <row halign="center">
-              <cell>AA A AA</cell>
-              <cell>B BB B</cell>
-            </row>
-          </tabular>
-        </table>
+  <table>
+    <title>Row option (borders)</title>
+    <tabular>
+      <row left="minor" bottom="medium">
+        <cell>A</cell>
+        <cell>B</cell>
+        <cell>C</cell>
+        <cell>D</cell>
+      </row>
+    </tabular>
+  </table>
 </FRAGMENT>
 ```
 
 ```ptx-example
 <FRAGMENT parents="section subsection">
   <table>
-          <title>Row option (valign)</title>
-          <tabular>
-          <col width="60%"/>
-          <col/>
-            <row valign="top" left="minor" bottom="minor">
-              <cell right="minor">
-                <p>
-                  We use a paragraph here to generate enough vertical space
-                   to demonstrate the vertical alignments.
-                </p>
-              </cell>
-              <cell>BBBBBB</cell>
-            </row>
-            <row valign="bottom" left="minor" bottom="minor">
-              <cell right="minor">
-                <p>
-                  We use a paragraph here to generate enough vertical space
-                   to demonstrate the vertical alignments.
-                </p>
-              </cell>
-              <cell>B</cell>
-            </row>
-            <row valign="middle" left="minor" bottom="minor">
-              <cell right="minor">
-                <p>
-                  We use a paragraph here to generate enough vertical space
-                   to demonstrate the vertical alignments.
-                </p>
-              </cell>
-              <cell>B BB B</cell>
-            </row>
-          </tabular>
-        </table>
+    <title>Row option (halign)</title>
+    <tabular>
+      <row halign="left">
+        <cell>AAAAAAAAAA</cell>
+        <cell>BBBBBB</cell>
+      </row>
+        <row halign="right">
+        <cell>A</cell>
+        <cell>B</cell>
+      </row>
+      <row halign="center">
+        <cell>AA A AA</cell>
+        <cell>B BB B</cell>
+      </row>
+    </tabular>
+  </table>
+</FRAGMENT>
+```
+
+```ptx-example
+<FRAGMENT parents="section subsection">
+  <table>
+    <title>Row option (valign)</title>
+    <tabular>
+    <col width="60%"/>
+    <col/>
+      <row valign="top" left="minor" bottom="minor">
+        <cell right="minor">
+          <p>
+            We use a paragraph here to generate enough vertical space
+              to demonstrate the vertical alignments.
+          </p>
+        </cell>
+        <cell>BBBBBB</cell>
+      </row>
+      <row valign="bottom" left="minor" bottom="minor">
+        <cell right="minor">
+          <p>
+            We use a paragraph here to generate enough vertical space
+              to demonstrate the vertical alignments.
+          </p>
+        </cell>
+        <cell>B</cell>
+      </row>
+      <row valign="middle" left="minor" bottom="minor">
+        <cell right="minor">
+          <p>
+            We use a paragraph here to generate enough vertical space
+              to demonstrate the vertical alignments.
+          </p>
+        </cell>
+        <cell>B BB B</cell>
+      </row>
+    </tabular>
+  </table>
  </FRAGMENT>
 ```

--- a/packages/docs/pages/reference/elements/table.mdx
+++ b/packages/docs/pages/reference/elements/table.mdx
@@ -10,7 +10,7 @@ import {
 
 The `<table>` tag is similar to the [`<figure>`](figure) tag,
 but is made to be wrapper for a [`<tabular>`](tabular). Using
-`<table>` tag allows the contained `<tabular>` to be referenced
+the `<table>` tag allows the contained `<tabular>` to be referenced
 by name. That is, a `<table>` will result in a label like
 "Table 1.2.3" appearing in your document.
 
@@ -150,7 +150,8 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
     </row>
     <row valign="top">
       <cell><p>
-        While horizontal alignment `halign`is allowed for each cell, vertical alignment `valign` is only permitted for each row.
+        While horizontal alignment `halign`is allowed for each cell, vertical
+         alignment `valign` is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>
@@ -158,7 +159,8 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
     </row>
     <row valign="middle">
       <cell><p>
-        While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row.
+        While horizontal alignment `halign` is allowed for each cell, vertical
+         alignment `valign` is only permitted for each row.
       </p></cell>
       <cell halign="left" >E</cell>
       <cell halign="center">F</cell>
@@ -166,7 +168,8 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
     </row>
     <row valign="bottom">
       <cell><p>
-        While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row.
+        While horizontal alignment `halign` is allowed for each cell, vertical
+         alignment `valign` is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>

--- a/packages/docs/pages/reference/elements/table.mdx
+++ b/packages/docs/pages/reference/elements/table.mdx
@@ -39,35 +39,35 @@ is the definitive source.
 
   ```ptx-example
 <FRAGMENT parents="subsection section">
-    <table>
-          <title>Sample check registry</title>
-          <tabular halign="right">
-            <row header="yes" bottom="minor" >
-              <cell right="minor">Date</cell>
-              <cell>Credit</cell>
-              <cell>Debit</cell>
-              <cell>Balance</cell>
-            </row>
-            <row>
-              <cell right="minor">Aug 1, 2024</cell>
-              <cell>100.27</cell>
-              <cell>0.00</cell>
-              <cell>5455.21</cell>
-            </row>
-            <row>
-              <cell right="minor">Aug 5, 2024</cell>
-              <cell>0.00</cell>
-              <cell>200.00</cell>
-              <cell>5255.21</cell>
-            </row>
-            <row>
-              <cell right="minor">Aug 12, 2024</cell>
-              <cell>23.45</cell>
-              <cell>0.00</cell>
-              <cell>5278.66</cell>
-            </row>
-          </tabular>
-        </table>
+  <table>
+    <title>Sample check registry</title>
+    <tabular halign="right">
+      <row header="yes" bottom="minor" >
+        <cell right="minor">Date</cell>
+        <cell>Credit</cell>
+        <cell>Debit</cell>
+        <cell>Balance</cell>
+      </row>
+      <row>
+        <cell right="minor">Aug 1, 2024</cell>
+        <cell>100.27</cell>
+        <cell>0.00</cell>
+        <cell>5455.21</cell>
+      </row>
+      <row>
+        <cell right="minor">Aug 5, 2024</cell>
+        <cell>0.00</cell>
+        <cell>200.00</cell>
+        <cell>5255.21</cell>
+      </row>
+      <row>
+        <cell right="minor">Aug 12, 2024</cell>
+        <cell>23.45</cell>
+        <cell>0.00</cell>
+        <cell>5278.66</cell>
+      </row>
+    </tabular>
+  </table>
 </FRAGMENT>
 ```
 
@@ -79,103 +79,103 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
 
 ```ptx-example
 <FRAGMENT parents="subsection section">
-    <table>
-          <title>Minimalist Pizza Order Form</title>
-          <tabular halign="center" top="minor" >
-            <col halign="left"/>
-            <col />
-            <col />
-            <col />
-            <col halign="right"/>
-            <row header="yes" left="minor">
-              <cell>Size</cell>
-              <cell colspan="3" halign="center">Toppings</cell>
-              <cell right="minor">Crust</cell>
-            </row>
-            <row bottom="minor" header="yes" left="minor">
-              <cell></cell>
-              <cell>
-                <c>Artichokes</c>
-              </cell>
-              <cell>
-                <c>Roni</c>
-              </cell>
-              <cell>
-                <c>Peppers</c>
-              </cell>
-              <cell right="minor">Regular/GF</cell>
-            </row>
-            <row left="minor">
-              <cell>Medium</cell>
-              <cell>X</cell>
-              <cell></cell>
-              <cell>X</cell>
-              <cell right="minor">GF</cell>
-            </row>
+  <table>
+    <title>Minimalist Pizza Order Form</title>
+    <tabular halign="center" top="minor" >
+      <col halign="left"/>
+      <col />
+      <col />
+      <col />
+      <col halign="right"/>
+      <row header="yes" left="minor">
+        <cell>Size</cell>
+        <cell colspan="3" halign="center">Toppings</cell>
+        <cell right="minor">Crust</cell>
+      </row>
+      <row bottom="minor" header="yes" left="minor">
+        <cell></cell>
+        <cell>
+          <c>Artichokes</c>
+        </cell>
+        <cell>
+          <c>Roni</c>
+        </cell>
+        <cell>
+          <c>Peppers</c>
+        </cell>
+        <cell right="minor">Regular/GF</cell>
+      </row>
+      <row left="minor">
+        <cell>Medium</cell>
+        <cell>X</cell>
+        <cell></cell>
+        <cell>X</cell>
+        <cell right="minor">GF</cell>
+      </row>
 
-            <row left="minor" bottom="minor">
-              <cell>Huge</cell>
-              <cell></cell>
-              <cell>X</cell>
-              <cell></cell>
-              <cell right="minor">Regular</cell>
-            </row>
-          </tabular>
-        </table>
-    </FRAGMENT>
+      <row left="minor" bottom="minor">
+        <cell>Huge</cell>
+        <cell></cell>
+        <cell>X</cell>
+        <cell></cell>
+        <cell right="minor">Regular</cell>
+      </row>
+    </tabular>
+  </table>
+</FRAGMENT>
 ```
 
 ### A table with paragraphs and alignment variations
 
 ```ptx-example
 <FRAGMENT parents="subsection section">
-<table>
-  <title>Tabular Options</title>
-  <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
-    <col width="40%"/>
-    <col/>
-    <col/>
-    <col/>
-    <row>
-      <cell>Paragraphs</cell>
-      <cell>Column 2</cell>
-      <cell>Column 3</cell>
-      <cell>Column 4</cell>
-    </row>
-    <row>
-      <cell halign="center"><p>The quick brown fox <ellipsis/></p></cell>
-      <cell>A</cell>
-      <cell halign="center">B</cell>
-      <cell halign="right">C</cell>
-    </row>
-    <row valign="top">
-      <cell><p>
-        While horizontal alignment `halign`is allowed for each cell, vertical
-         alignment `valign` is only permitted for each row.
-      </p></cell>
-      <cell halign="left">E</cell>
-      <cell halign="center">F</cell>
-      <cell halign="right">G</cell>
-    </row>
-    <row valign="middle">
-      <cell><p>
-        While horizontal alignment `halign` is allowed for each cell, vertical
-         alignment `valign` is only permitted for each row.
-      </p></cell>
-      <cell halign="left" >E</cell>
-      <cell halign="center">F</cell>
-      <cell halign="right">G</cell>
-    </row>
-    <row valign="bottom">
-      <cell><p>
-        While horizontal alignment `halign` is allowed for each cell, vertical
-         alignment `valign` is only permitted for each row.
-      </p></cell>
-      <cell halign="left">E</cell>
-      <cell halign="center">F</cell>
-      <cell halign="right">G</cell>
-    </row>
-  </tabular>
-</table>
+  <table>
+    <title>Tabular Options</title>
+    <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
+      <col width="40%"/>
+      <col/>
+      <col/>
+      <col/>
+      <row>
+        <cell>Paragraphs</cell>
+        <cell>Column 2</cell>
+        <cell>Column 3</cell>
+        <cell>Column 4</cell>
+      </row>
+      <row>
+        <cell halign="center"><p>The quick brown fox <ellipsis/></p></cell>
+        <cell>A</cell>
+        <cell halign="center">B</cell>
+        <cell halign="right">C</cell>
+      </row>
+      <row valign="top">
+        <cell><p>
+          While horizontal alignment `halign`is allowed for each cell, vertical
+          alignment `valign` is only permitted for each row.
+        </p></cell>
+        <cell halign="left">E</cell>
+        <cell halign="center">F</cell>
+        <cell halign="right">G</cell>
+      </row>
+      <row valign="middle">
+        <cell><p>
+          While horizontal alignment `halign` is allowed for each cell, vertical
+          alignment `valign` is only permitted for each row.
+        </p></cell>
+        <cell halign="left" >E</cell>
+        <cell halign="center">F</cell>
+        <cell halign="right">G</cell>
+      </row>
+      <row valign="bottom">
+        <cell><p>
+          While horizontal alignment `halign` is allowed for each cell, vertical
+          alignment `valign` is only permitted for each row.
+        </p></cell>
+        <cell halign="left">E</cell>
+        <cell halign="center">F</cell>
+        <cell halign="right">G</cell>
+      </row>
+    </tabular>
+  </table>
 </FRAGMENT>
 ```

--- a/packages/docs/pages/reference/elements/table.mdx
+++ b/packages/docs/pages/reference/elements/table.mdx
@@ -8,27 +8,29 @@ import {
 
 # `<table>`
 
-The `<table>` tag produces a container for the [`<tabular>`](./tabular) tag and assigns to it a number which can be associated with a title for table. The [`<tabular>`](./tabular) tag produces what one normally thinks of as a table
-consisting of rows and columns.  For complex tables, there is an [online table
-builder](https://www.latex-tables.com/) which can generate PreTeXt output.
+The `<table>` tag is similar to the [`<figure>`](figure) tag,
+but is made to be wrapper for a [`<tabular>`](tabular). Using
+`<table>` tag allows the contained `<tabular>` to be referenced
+by name. That is, a `<table>` will result in a label like
+"Table 1.2.3" appearing in your document.
 
 ## Syntax
 
 <SyntaxDisplay name="table" />
 
-## Examples
+## Notes
 
-### A comment about table borders
+### A note about table borders
 
 Placing borders in tables exactly where you want them requires that you
 understand in which elements the attributes `top`, `left`, `bottom`, and
 `right` may be applied. Note that while horizontal borders (rules)
  are easy, vertical rules have been made intentionally more work "to gently
  guide authors towards good choices" in document design.
-[Table 4.18.3]
-(https://pretextbook.org/doc/guide/html/topic-tabular.html#topic-tabular-13-7)
+The section of the PreTeXt Guide on `Tables and Tabulars`
 is the definitive source.
 
+## Examples
 
 ### A simple table
 
@@ -61,7 +63,7 @@ is the definitive source.
             <row>
               <cell right="minor">Aug 12, 2024</cell>
               <cell>23.45</cell>
-              <cell>0</cell>
+              <cell>0.00</cell>
               <cell>5278.66</cell>
             </row>
           </tabular>
@@ -125,7 +127,6 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
 
 ### A table with paragraphs and alignment variations
 
-
 ```ptx-example
 <FRAGMENT parents="subsection section">
 <table>
@@ -149,7 +150,7 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
     </row>
     <row valign="top">
       <cell><p>
-        "While horizontal alignment `halign`is allowed for each cell, vertical alignment `valign` is only permitted for each row"
+        While horizontal alignment `halign`is allowed for each cell, vertical alignment `valign` is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>
@@ -157,7 +158,7 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
     </row>
     <row valign="middle">
       <cell><p>
-        "While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row"
+        While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row.
       </p></cell>
       <cell halign="left" >E</cell>
       <cell halign="center">F</cell>
@@ -165,7 +166,7 @@ alignment of [`<cell>`](./cell) entries in different columns as well as a
     </row>
     <row valign="bottom">
       <cell><p>
-        "While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row"
+        While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>

--- a/packages/docs/pages/reference/elements/table.mdx
+++ b/packages/docs/pages/reference/elements/table.mdx
@@ -8,7 +8,9 @@ import {
 
 # `<table>`
 
-Short description of what the `<table>` tag does.
+The `<table>` tag produces a container for the [`<tabular>`](./tabular) tag and assigns to it a number which can be associated with a title for table. The [`<tabular>`](./tabular) tag produces what one normally thinks of as a table
+consisting of rows and columns.  For complex tables, there is an [online table
+builder](https://www.latex-tables.com/) which can generate PreTeXt output.
 
 ## Syntax
 
@@ -16,4 +18,160 @@ Short description of what the `<table>` tag does.
 
 ## Examples
 
-    
+### A comment about table borders
+
+Placing borders in tables exactly where you want them requires that you
+understand in which elements the attributes `top`, `left`, `bottom`, and
+`right` may be applied. Note that while horizontal borders (rules)
+ are easy, vertical rules have been made intentionally more work "to gently
+ guide authors towards good choices" in document design.
+[Table 4.18.3]
+(https://pretextbook.org/doc/guide/html/topic-tabular.html#topic-tabular-13-7)
+is the definitive source.
+
+
+### A simple table
+
+ In this example, all cell entries are right-justified; the table has a header
+ row and some cells have borders.
+
+  ```ptx-example
+<FRAGMENT parents="subsection section">
+    <table>
+          <title>Sample check registry</title>
+          <tabular halign="right">
+            <row header="yes" bottom="minor" >
+              <cell right="minor">Date</cell>
+              <cell>Credit</cell>
+              <cell>Debit</cell>
+              <cell>Balance</cell>
+            </row>
+            <row>
+              <cell right="minor">Aug 1, 2024</cell>
+              <cell>100.27</cell>
+              <cell>0.00</cell>
+              <cell>5455.21</cell>
+            </row>
+            <row>
+              <cell right="minor">Aug 5, 2024</cell>
+              <cell>0.00</cell>
+              <cell>200.00</cell>
+              <cell>5255.21</cell>
+            </row>
+            <row>
+              <cell right="minor">Aug 12, 2024</cell>
+              <cell>23.45</cell>
+              <cell>0</cell>
+              <cell>5278.66</cell>
+            </row>
+          </tabular>
+        </table>
+</FRAGMENT>
+```
+
+### A slightly more complicated table.
+
+In this example, we use the [`<col>`](./col) tag to set the horizontal
+alignment of [`<cell>`](./cell) entries in different columns as well as a
+`colspan` option in one of the header cells.
+
+```ptx-example
+<FRAGMENT parents="subsection section">
+    <table>
+          <title>Minimalist Pizza Order Form</title>
+          <tabular halign="center" top="minor" >
+            <col halign="left"/>
+            <col />
+            <col />
+            <col />
+            <col halign="right"/>
+            <row header="yes" left="minor">
+              <cell>Size</cell>
+              <cell colspan="3" halign="center">Toppings</cell>
+              <cell right="minor">Crust</cell>
+            </row>
+            <row bottom="minor" header="yes" left="minor">
+              <cell></cell>
+              <cell>
+                <c>Artichokes</c>
+              </cell>
+              <cell>
+                <c>Roni</c>
+              </cell>
+              <cell>
+                <c>Peppers</c>
+              </cell>
+              <cell right="minor">Regular/GF</cell>
+            </row>
+            <row left="minor">
+              <cell>Medium</cell>
+              <cell>X</cell>
+              <cell></cell>
+              <cell>X</cell>
+              <cell right="minor">GF</cell>
+            </row>
+
+            <row left="minor" bottom="minor">
+              <cell>Huge</cell>
+              <cell></cell>
+              <cell>X</cell>
+              <cell></cell>
+              <cell right="minor">Regular</cell>
+            </row>
+          </tabular>
+        </table>
+    </FRAGMENT>
+```
+
+### A table with paragraphs and alignment variations
+
+
+```ptx-example
+<FRAGMENT parents="subsection section">
+<table>
+  <title>Tabular Options</title>
+  <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
+    <col width="40%"/>
+    <col/>
+    <col/>
+    <col/>
+    <row>
+      <cell>Paragraphs</cell>
+      <cell>Column 2</cell>
+      <cell>Column 3</cell>
+      <cell>Column 4</cell>
+    </row>
+    <row>
+      <cell halign="center"><p>The quick brown fox <ellipsis/></p></cell>
+      <cell>A</cell>
+      <cell halign="center">B</cell>
+      <cell halign="right">C</cell>
+    </row>
+    <row valign="top">
+      <cell><p>
+        "While horizontal alignment `halign`is allowed for each cell, vertical alignment `valign` is only permitted for each row"
+      </p></cell>
+      <cell halign="left">E</cell>
+      <cell halign="center">F</cell>
+      <cell halign="right">G</cell>
+    </row>
+    <row valign="middle">
+      <cell><p>
+        "While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row"
+      </p></cell>
+      <cell halign="left" >E</cell>
+      <cell halign="center">F</cell>
+      <cell halign="right">G</cell>
+    </row>
+    <row valign="bottom">
+      <cell><p>
+        "While horizontal alignment `halign` is allowed for each cell, vertical alignment `valign` is only permitted for each row"
+      </p></cell>
+      <cell halign="left">E</cell>
+      <cell halign="center">F</cell>
+      <cell halign="right">G</cell>
+    </row>
+  </tabular>
+</table>
+</FRAGMENT>
+```

--- a/packages/docs/pages/reference/elements/tabular.mdx
+++ b/packages/docs/pages/reference/elements/tabular.mdx
@@ -39,35 +39,35 @@ is the definitive source.
 
   ```ptx-example
 <FRAGMENT parents="subsection section">
-    <table>
-          <title>Sample check registry</title>
-          <tabular halign="right">
-            <row header="yes" bottom="minor" >
-              <cell right="minor">Date</cell>
-              <cell>Credit</cell>
-              <cell>Debit</cell>
-              <cell>Balance</cell>
-            </row>
-            <row>
-              <cell right="minor">Aug 1, 2024</cell>
-              <cell>100.27</cell>
-              <cell>0.00</cell>
-              <cell>5455.21</cell>
-            </row>
-            <row>
-              <cell right="minor">Aug 5, 2024</cell>
-              <cell>0.00</cell>
-              <cell>200.00</cell>
-              <cell>5255.21</cell>
-            </row>
-            <row>
-              <cell right="minor">Aug 12, 2024</cell>
-              <cell>23.45</cell>
-              <cell>0.00</cell>
-              <cell>5278.66</cell>
-            </row>
-          </tabular>
-        </table>
+  <table>
+    <title>Sample check registry</title>
+    <tabular halign="right">
+      <row header="yes" bottom="minor" >
+        <cell right="minor">Date</cell>
+        <cell>Credit</cell>
+        <cell>Debit</cell>
+        <cell>Balance</cell>
+      </row>
+      <row>
+        <cell right="minor">Aug 1, 2024</cell>
+        <cell>100.27</cell>
+        <cell>0.00</cell>
+        <cell>5455.21</cell>
+      </row>
+      <row>
+        <cell right="minor">Aug 5, 2024</cell>
+        <cell>0.00</cell>
+        <cell>200.00</cell>
+        <cell>5255.21</cell>
+      </row>
+      <row>
+        <cell right="minor">Aug 12, 2024</cell>
+        <cell>23.45</cell>
+        <cell>0.00</cell>
+        <cell>5278.66</cell>
+      </row>
+    </tabular>
+  </table>
 </FRAGMENT>
 ```
 
@@ -76,115 +76,115 @@ is the definitive source.
 ```ptx-example
 <FRAGMENT parents="subsection section">
   <activity>
-          <p> Many positive integers can be represented as the sum of three
-           integer cubes: <m>n =
-            x^3 + y^3 +z^3.</m> Exactly one of <m>n = 12, 13</m> can be
-             represented as the sum of three cubes. Determine a representation
-              for the one that can, and a reason for the one that cannot. </p>
+    <p> Many positive integers can be represented as the sum of three
+      integer cubes: <m>n =
+      x^3 + y^3 +z^3.</m> Exactly one of <m>n = 12, 13</m> can be
+        represented as the sum of three cubes. Determine a representation
+        for the one that can, and a reason for the one that cannot. </p>
 
-          <hint>
-            <p> For the one that is representable, the absolute values of
-             <m>x,y,z</m> are all less than 12. </p>
-          </hint>
-          <hint>
-            <p>
-              For the one that is not representable, consider the values of
-               cubes modulo 9.
-            </p>
-          </hint>
+    <hint>
+      <p> For the one that is representable, the absolute values of
+        <m>x,y,z</m> are all less than 12. </p>
+    </hint>
+    <hint>
+      <p>
+        For the one that is not representable, consider the values of
+          cubes modulo 9.
+      </p>
+    </hint>
 
-          <tabular halign="center">
-              <row header="yes" bottom="minor">
-                <cell>n</cell>
-                <cell>x</cell>
-                <cell>y</cell>
-                <cell>z</cell>
-              </row>
+    <tabular halign="center">
+        <row header="yes" bottom="minor">
+          <cell>n</cell>
+          <cell>x</cell>
+          <cell>y</cell>
+          <cell>z</cell>
+        </row>
 
-              <row>
-                <cell>10</cell>
-                <cell>1</cell>
-                <cell>1</cell>
-                <cell>2</cell>
-              </row>
+        <row>
+          <cell>10</cell>
+          <cell>1</cell>
+          <cell>1</cell>
+          <cell>2</cell>
+        </row>
 
-              <row>
-                <cell>11</cell>
-                <cell>-2</cell>
-                <cell>-2</cell>
-                <cell>3</cell>
-              </row>
+        <row>
+          <cell>11</cell>
+          <cell>-2</cell>
+          <cell>-2</cell>
+          <cell>3</cell>
+        </row>
 
-              <row>
-                <cell>12</cell>
-                <cell></cell>
-                <cell></cell>
-                <cell></cell>
-              </row>
+        <row>
+          <cell>12</cell>
+          <cell></cell>
+          <cell></cell>
+          <cell></cell>
+        </row>
 
-              <row>
-                <cell>13</cell>
-                <cell></cell>
-                <cell></cell>
-                <cell></cell>
-              </row>
-          </tabular>
-        </activity>
-    </FRAGMENT>
+        <row>
+          <cell>13</cell>
+          <cell></cell>
+          <cell></cell>
+          <cell></cell>
+        </row>
+    </tabular>
+  </activity>
+</FRAGMENT>
 ```
 
 ### A table with paragraphs and alignment variations
 
 ```ptx-example
 <FRAGMENT parents="subsection section">
-<table>
-  <title>Tabular Alignment Options</title>
-  <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
-    <col width="40%"/>
-    <col/>
-    <col/>
-    <col/>
-    <row>
-      <cell>Paragraphs</cell>
-      <cell>Column 2</cell>
-      <cell>Column 3</cell>
-      <cell>Column 4</cell>
-    </row>
-    <row>
-      <cell halign="center"><p>The quick brown fox <ellipsis/></p></cell>
-      <cell>A</cell>
-      <cell halign="center">B</cell>
-      <cell halign="right">C</cell>
-    </row>
-    <row valign="top">
-      <cell><p>
-        While horizontal alignment (halign) is allowed for each cell,
-         vertical alignment (valign) is only permitted for each row.
-      </p></cell>
-      <cell halign="left">E</cell>
-      <cell halign="center">F</cell>
-      <cell halign="right">G</cell>
-    </row>
-    <row valign="middle">
-      <cell><p>
-        While horizontal alignment (halign) is allowed for each cell,
-         vertical alignment (valign) is only permitted for each row.
-      </p></cell>
-      <cell halign="left" >E</cell>
-      <cell halign="center">F</cell>
-      <cell halign="right">G</cell>
-    </row>
-    <row valign="bottom">
-      <cell><p>
-        While horizontal alignment (halign) is allowed for each cell,
-         vertical alignment (valign) is only permitted for each row.
-      </p></cell>
-      <cell halign="left">E</cell>
-      <cell halign="center">F</cell>
-      <cell halign="right">G</cell>
-    </row>
-  </tabular>
-</table>
+  <table>
+    <title>Tabular Alignment Options</title>
+    <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
+      <col width="40%"/>
+      <col/>
+      <col/>
+      <col/>
+      <row>
+        <cell>Paragraphs</cell>
+        <cell>Column 2</cell>
+        <cell>Column 3</cell>
+        <cell>Column 4</cell>
+      </row>
+      <row>
+        <cell halign="center"><p>The quick brown fox <ellipsis/></p></cell>
+        <cell>A</cell>
+        <cell halign="center">B</cell>
+        <cell halign="right">C</cell>
+      </row>
+      <row valign="top">
+        <cell><p>
+          While horizontal alignment (halign) is allowed for each cell,
+          vertical alignment (valign) is only permitted for each row.
+        </p></cell>
+        <cell halign="left">E</cell>
+        <cell halign="center">F</cell>
+        <cell halign="right">G</cell>
+      </row>
+      <row valign="middle">
+        <cell><p>
+          While horizontal alignment (halign) is allowed for each cell,
+          vertical alignment (valign) is only permitted for each row.
+        </p></cell>
+        <cell halign="left" >E</cell>
+        <cell halign="center">F</cell>
+        <cell halign="right">G</cell>
+      </row>
+      <row valign="bottom">
+        <cell><p>
+          While horizontal alignment (halign) is allowed for each cell,
+          vertical alignment (valign) is only permitted for each row.
+        </p></cell>
+        <cell halign="left">E</cell>
+        <cell halign="center">F</cell>
+        <cell halign="right">G</cell>
+      </row>
+    </tabular>
+  </table>
 
 </FRAGMENT>
 ```

--- a/packages/docs/pages/reference/elements/tabular.mdx
+++ b/packages/docs/pages/reference/elements/tabular.mdx
@@ -78,17 +78,18 @@ is the definitive source.
   <activity>
           <p> Many positive integers can be represented as the sum of three
            integer cubes: <m>n =
-            x^3 + y^3 +z^3.</m> Exactly one of <m>n = 12, 13</m> can be represented as the sum of
-            three cubes. Determine a representation for the one that can, and a reason for the one
-            that cannot. </p>
+            x^3 + y^3 +z^3.</m> Exactly one of <m>n = 12, 13</m> can be
+             represented as the sum of three cubes. Determine a representation
+              for the one that can, and a reason for the one that cannot. </p>
 
           <hint>
-            <p> For the one that is representable, the absolute values of <m>x,y,z</m> are all less
-              than 12. </p>
+            <p> For the one that is representable, the absolute values of
+             <m>x,y,z</m> are all less than 12. </p>
           </hint>
           <hint>
             <p>
-              For the one that is not representable, consider the values of cubes modulo 9.
+              For the one that is not representable, consider the values of
+               cubes modulo 9.
             </p>
           </hint>
 
@@ -157,7 +158,8 @@ is the definitive source.
     </row>
     <row valign="top">
       <cell><p>
-        While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row.
+        While horizontal alignment (halign) is allowed for each cell,
+         vertical alignment (valign) is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>
@@ -165,7 +167,8 @@ is the definitive source.
     </row>
     <row valign="middle">
       <cell><p>
-        While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row.
+        While horizontal alignment (halign) is allowed for each cell,
+         vertical alignment (valign) is only permitted for each row.
       </p></cell>
       <cell halign="left" >E</cell>
       <cell halign="center">F</cell>
@@ -173,7 +176,8 @@ is the definitive source.
     </row>
     <row valign="bottom">
       <cell><p>
-        While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row.
+        While horizontal alignment (halign) is allowed for each cell,
+         vertical alignment (valign) is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>

--- a/packages/docs/pages/reference/elements/tabular.mdx
+++ b/packages/docs/pages/reference/elements/tabular.mdx
@@ -1,133 +1,133 @@
 import {
-    AttrDisplay,
-    ChildrenDisplay,
-    ParentsDisplay,
-    PtxExample,
-    SyntaxDisplay,
+  AttrDisplay,
+  ChildrenDisplay,
+  ParentsDisplay,
+  PtxExample,
+  SyntaxDisplay,
 } from "../../../components";
 
 # `<tabular>`
 
 The `<tabular>` tag is the workhorse tag for displaying a collection of cells
-presented in rows and columns.  For complex tables, there is an [online table
+presented in rows and columns; in most contexts this environment would be
+called a table, but in PreTeXt a `<table>` is simply one of many possible
+wrappers for a `<tabular>`. For complex tabulars, there is an [online table
 builder](https://www.latex-tables.com/) which can generate PreTeXt output.
-
 
 ## Syntax
 
 <SyntaxDisplay name="tabular" />
 
+## Notes
+
+### A note about tabular borders
+
+Placing borders in tabulars exactly where you want them requires that you
+understand in which elements the attributes `top`, `left`, `bottom`, and
+`right` may be applied. Note that while horizontal borders (rules)
+ are easy, vertical rules have been made intentionally more work "to gently
+ guide authors towards good choices" in document design.
+The section of the PreTeXt Guide on `Tables and Tabulars`
+is the definitive source.
+
 ## Examples
+
+### A simple tabular wrapper in a `<table>`.
+
+ In this example, all cell entries are right-justified; the table has a header
+ row and some cells have borders.
+
+  ```ptx-example
+<FRAGMENT parents="subsection section">
+    <table>
+          <title>Sample check registry</title>
+          <tabular halign="right">
+            <row header="yes" bottom="minor" >
+              <cell right="minor">Date</cell>
+              <cell>Credit</cell>
+              <cell>Debit</cell>
+              <cell>Balance</cell>
+            </row>
+            <row>
+              <cell right="minor">Aug 1, 2024</cell>
+              <cell>100.27</cell>
+              <cell>0.00</cell>
+              <cell>5455.21</cell>
+            </row>
+            <row>
+              <cell right="minor">Aug 5, 2024</cell>
+              <cell>0.00</cell>
+              <cell>200.00</cell>
+              <cell>5255.21</cell>
+            </row>
+            <row>
+              <cell right="minor">Aug 12, 2024</cell>
+              <cell>23.45</cell>
+              <cell>0.00</cell>
+              <cell>5278.66</cell>
+            </row>
+          </tabular>
+        </table>
+</FRAGMENT>
+```
 
 ### A tabular example wrapped by an `<activity>` instead of a `<table>`.
 
 ```ptx-example
 <FRAGMENT parents="subsection section">
-    <activity>
-          <p> Which numbers between 1 and 10 can be represented as the
-          sum of three integer cubes: <m>n = x^3 + y^3 +z^3?</m>
-          </p>
+  <activity>
+          <p> Many positive integers can be represented as the sum of three
+           integer cubes: <m>n =
+            x^3 + y^3 +z^3.</m> Exactly one of <m>n = 12, 13</m> can be represented as the sum of
+            three cubes. Determine a representation for the one that can, and a reason for the one
+            that cannot. </p>
 
-          <p>
-            If they can, give a solution. If they cannot, give a reason.
-            As the table below shows, not all integers that can be so
-            represented have simple solutions.
-          </p>
+          <hint>
+            <p> For the one that is representable, the absolute values of <m>x,y,z</m> are all less
+              than 12. </p>
+          </hint>
+          <hint>
+            <p>
+              For the one that is not representable, consider the values of cubes modulo 9.
+            </p>
+          </hint>
 
-          <p>
-            <tabular halign="center">
+          <tabular halign="center">
               <row header="yes" bottom="minor">
                 <cell>n</cell>
                 <cell>x</cell>
                 <cell>y</cell>
                 <cell>z</cell>
               </row>
-              <row>
-                <cell>1</cell>
-                <cell>0</cell>
-                <cell>0</cell>
-                <cell>1</cell>
-              </row>
-
-              <row>
-                <cell>1</cell>
-                <cell><m>9b^4</m></cell>
-                <cell><m>3b-9b^4</m></cell>
-                <cell><m>1-9b^3</m></cell>
-              </row>
-
-              <row>
-                <cell>2</cell>
-                <cell>1</cell>
-                <cell>1</cell>
-                <cell>0</cell>
-              </row>
-
-              <row>
-                <cell>3</cell>
-                <cell>1</cell>
-                <cell>1</cell>
-                <cell>1</cell>
-              </row>
-
-              <row>
-                <cell>4</cell>
-                <cell></cell>
-                <cell></cell>
-                <cell></cell>
-              </row>
-
-              <row>
-                <cell>5</cell>
-                <cell></cell>
-                <cell></cell>
-                <cell></cell>
-              </row>
-
-              <row>
-                <cell>6</cell>
-                <cell><m>-1</m></cell>
-                <cell><m>-1</m></cell>
-                <cell><m>2</m>
-                </cell>
-              </row>
-
-              <row>
-                <cell>7</cell>
-                <cell></cell>
-                <cell></cell>
-                <cell></cell>
-              </row>
-
-              <row>
-                <cell>8</cell>
-                <cell></cell>
-                <cell></cell>
-                <cell></cell>
-              </row>
-
-              <row>
-                <cell>9</cell>
-                <cell></cell>
-                <cell></cell>
-                <cell></cell>
-              </row>
 
               <row>
                 <cell>10</cell>
+                <cell>1</cell>
+                <cell>1</cell>
+                <cell>2</cell>
+              </row>
+
+              <row>
+                <cell>11</cell>
+                <cell>-2</cell>
+                <cell>-2</cell>
+                <cell>3</cell>
+              </row>
+
+              <row>
+                <cell>12</cell>
                 <cell></cell>
                 <cell></cell>
                 <cell></cell>
               </row>
 
               <row>
-                <cell>42</cell>
-                <cell><m>-80,538,738,812,075,974</m></cell>
-                <cell><m>80,435,758,145,817,515</m></cell>
-                <cell><m>12,602,123,297335,631</m></cell>
+                <cell>13</cell>
+                <cell></cell>
+                <cell></cell>
+                <cell></cell>
               </row>
-            </tabular>
-          </p>
+          </tabular>
         </activity>
     </FRAGMENT>
 ```
@@ -137,7 +137,7 @@ builder](https://www.latex-tables.com/) which can generate PreTeXt output.
 ```ptx-example
 <FRAGMENT parents="subsection section">
 <table>
-  <title>Tabular Options</title>
+  <title>Tabular Alignment Options</title>
   <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
     <col width="40%"/>
     <col/>
@@ -157,7 +157,7 @@ builder](https://www.latex-tables.com/) which can generate PreTeXt output.
     </row>
     <row valign="top">
       <cell><p>
-        "While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row"
+        While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>
@@ -165,7 +165,7 @@ builder](https://www.latex-tables.com/) which can generate PreTeXt output.
     </row>
     <row valign="middle">
       <cell><p>
-        "While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row"
+        While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row.
       </p></cell>
       <cell halign="left" >E</cell>
       <cell halign="center">F</cell>
@@ -173,7 +173,7 @@ builder](https://www.latex-tables.com/) which can generate PreTeXt output.
     </row>
     <row valign="bottom">
       <cell><p>
-        "While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row"
+        While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row.
       </p></cell>
       <cell halign="left">E</cell>
       <cell halign="center">F</cell>

--- a/packages/docs/pages/reference/elements/tabular.mdx
+++ b/packages/docs/pages/reference/elements/tabular.mdx
@@ -8,7 +8,10 @@ import {
 
 # `<tabular>`
 
-Short description of what the `<tabular>` tag does.
+The `<tabular>` tag is the workhorse tag for displaying a collection of cells
+presented in rows and columns.  For complex tables, there is an [online table
+builder](https://www.latex-tables.com/) which can generate PreTeXt output.
+
 
 ## Syntax
 
@@ -16,4 +19,168 @@ Short description of what the `<tabular>` tag does.
 
 ## Examples
 
-    
+### A tabular example wrapped by an `<activity>` instead of a `<table>`.
+
+```ptx-example
+<FRAGMENT parents="subsection section">
+    <activity>
+          <p> Which numbers between 1 and 10 can be represented as the
+          sum of three integer cubes: <m>n = x^3 + y^3 +z^3?</m>
+          </p>
+
+          <p>
+            If they can, give a solution. If they cannot, give a reason.
+            As the table below shows, not all integers that can be so
+            represented have simple solutions.
+          </p>
+
+          <p>
+            <tabular halign="center">
+              <row header="yes" bottom="minor">
+                <cell>n</cell>
+                <cell>x</cell>
+                <cell>y</cell>
+                <cell>z</cell>
+              </row>
+              <row>
+                <cell>1</cell>
+                <cell>0</cell>
+                <cell>0</cell>
+                <cell>1</cell>
+              </row>
+
+              <row>
+                <cell>1</cell>
+                <cell><m>9b^4</m></cell>
+                <cell><m>3b-9b^4</m></cell>
+                <cell><m>1-9b^3</m></cell>
+              </row>
+
+              <row>
+                <cell>2</cell>
+                <cell>1</cell>
+                <cell>1</cell>
+                <cell>0</cell>
+              </row>
+
+              <row>
+                <cell>3</cell>
+                <cell>1</cell>
+                <cell>1</cell>
+                <cell>1</cell>
+              </row>
+
+              <row>
+                <cell>4</cell>
+                <cell></cell>
+                <cell></cell>
+                <cell></cell>
+              </row>
+
+              <row>
+                <cell>5</cell>
+                <cell></cell>
+                <cell></cell>
+                <cell></cell>
+              </row>
+
+              <row>
+                <cell>6</cell>
+                <cell><m>-1</m></cell>
+                <cell><m>-1</m></cell>
+                <cell><m>2</m>
+                </cell>
+              </row>
+
+              <row>
+                <cell>7</cell>
+                <cell></cell>
+                <cell></cell>
+                <cell></cell>
+              </row>
+
+              <row>
+                <cell>8</cell>
+                <cell></cell>
+                <cell></cell>
+                <cell></cell>
+              </row>
+
+              <row>
+                <cell>9</cell>
+                <cell></cell>
+                <cell></cell>
+                <cell></cell>
+              </row>
+
+              <row>
+                <cell>10</cell>
+                <cell></cell>
+                <cell></cell>
+                <cell></cell>
+              </row>
+
+              <row>
+                <cell>42</cell>
+                <cell><m>-80,538,738,812,075,974</m></cell>
+                <cell><m>80,435,758,145,817,515</m></cell>
+                <cell><m>12,602,123,297335,631</m></cell>
+              </row>
+            </tabular>
+          </p>
+        </activity>
+    </FRAGMENT>
+```
+
+### A table with paragraphs and alignment variations
+
+```ptx-example
+<FRAGMENT parents="subsection section">
+<table>
+  <title>Tabular Options</title>
+  <tabular left="minor" right="minor" top="minor" bottom="minor" valign="top">
+    <col width="40%"/>
+    <col/>
+    <col/>
+    <col/>
+    <row>
+      <cell>Paragraphs</cell>
+      <cell>Column 2</cell>
+      <cell>Column 3</cell>
+      <cell>Column 4</cell>
+    </row>
+    <row>
+      <cell halign="center"><p>The quick brown fox <ellipsis/></p></cell>
+      <cell>A</cell>
+      <cell halign="center">B</cell>
+      <cell halign="right">C</cell>
+    </row>
+    <row valign="top">
+      <cell><p>
+        "While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row"
+      </p></cell>
+      <cell halign="left">E</cell>
+      <cell halign="center">F</cell>
+      <cell halign="right">G</cell>
+    </row>
+    <row valign="middle">
+      <cell><p>
+        "While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row"
+      </p></cell>
+      <cell halign="left" >E</cell>
+      <cell halign="center">F</cell>
+      <cell halign="right">G</cell>
+    </row>
+    <row valign="bottom">
+      <cell><p>
+        "While horizontal alignment (halign) is allowed for each cell, vertical alignment (valign) is only permitted for each row"
+      </p></cell>
+      <cell halign="left">E</cell>
+      <cell halign="center">F</cell>
+      <cell halign="right">G</cell>
+    </row>
+  </tabular>
+</table>
+
+</FRAGMENT>
+```


### PR DESCRIPTION
Here is the first draft of these five tags.  I have some overlapping but reasonably broad starting examples which populate `<tables>` and `<tabular>`.  I redirected examples for `<col>`, `<row>` and `<cell>` to the table/tabular pages.

We could obviously rethink that, but I would need to know have to represent a code snippet as a fragment in this mark down setting.

Of course, now that there is something to talk about, we can discuss how to improve these pages.  In particular, if there are other examples you have in mind or features to demonstrate, let me know.