### PR TITLE
mrow

### DIFF
--- a/packages/docs/pages/reference/elements/mrow.mdx
+++ b/packages/docs/pages/reference/elements/mrow.mdx
@@ -8,12 +8,43 @@ import {
 
 # `<mrow>`
 
-Short description of what the `<mrow>` tag does.
+The `<mrow>` tag is used for aligned rows of mathematics within an `<md>` or `<mdn>` tag.  The odd-numbered 
+`\amp` provide the align points, while even-numbered `\amp` provide spacing.  
 
 ## Syntax
 
 <SyntaxDisplay name="mrow" />
 
 ## Examples
+
+### Aligning three rows
+
+```ptx-example
+<FRAGMENT parents="p">
+    <md>
+        <mrow>
+            2x(x+5)(x-3) \amp = 2x\left(x\cdot x -3x +5x-15\right)
+        </mrow>
+        <mrow>
+            \amp = 2x\left(x^2+2x-15\right)
+        </mrow>
+        <mrow>
+            \amp = 2x^3+4x^2-30x
+        </mrow>
+    </md>
+</FRAGMENT>
+```
+
+### Rows that are both aligned and spaced out; within a row, odd-numbered `\amp` provide align points while even-numbered `\amp` provide spacing
+
+```ptx-example
+<FRAGMENT>
+    <md>
+        <mrow> \amp x_1\amp \amp +  \amp \amp x_2\amp \amp \amp \amp \amp \amp = 800 </mrow>
+        <mrow> \amp \amp \amp \amp \amp x_2\amp  \amp +\amp   \amp x_3\amp \amp = 608 </mrow>
+        <mrow> \amp x_1  \amp \amp +\amp  \amp \amp  \amp \amp  \amp x_3\amp \amp =612 </mrow>
+    </md>
+</FRAGMENT>
+```
 
     


### PR DESCRIPTION
Made my examples have the `<md>` in them also - that seemed better to me than trying to put md as parent, if that would even work.  Let me know if I should have done it differently!